### PR TITLE
Allow for setting individual options

### DIFF
--- a/glicko2.js
+++ b/glicko2.js
@@ -125,21 +125,30 @@
 
     //=========================  Glicko2 class =============================================
     function Glicko2(settings){
-        default_settings = {
-            tau : 0.5, // Internal glicko2 parameter. "Reasonable choices are between 0.3 and 1.2, though the system should be tested to decide which value results in greatest predictive accuracy."
-            rating : 1500, //default rating
-            rd : 350, //Default rating deviation (small number = good confidence on the rating accuracy)
-            vol : 0.06, //Default volatility (expected fluctation on the player rating)
-            volatility_algorithm : 'newprocedure' //Default volatility calculation algorithm (step 5 of the global algorithm)
-        };
-        settings = settings || default_settings;
-        Player.prototype.defaultRating = settings.rating;
-        Player.prototype.volatility_algorithm = volatility_algorithms[settings.volatility_algorithm || default_settings.volatility_algorithm];
+        settings = settings || {};
 
-        this._tau = settings.tau;
-        this._default_rating = settings.rating;
-        this._default_rd = settings.rd;
-        this._default_vol = settings.vol;
+        // Default rating
+        Player.prototype.defaultRating = settings.rating || 1500;
+
+        // Defualt volatility calculation algorithm (step 5 of the global
+        // algorithm)
+        Player.prototype.volatility_algorithm = volatility_algorithms[settings.volatility_algorithm || 'newprocedure'];
+
+        // Internal glicko2 paramter. "Reasonable choices are between 0.3 and
+        // 1.2, though the system should be tested to decide which value results
+        // in greatest predictive accuracy."
+        this._tau = settings.tau || 0.5;
+
+        // Default rating
+        this._default_rating = settings.rating || 1500;
+
+        // Default rating deviation (small number = good confidence on the
+        // rating accuracy)
+        this._default_rd = settings.rd || 350;
+
+        // Default volatility (expected fluctation on the player rating)
+        this._default_vol = settings.vol || 0.06;
+
         this.players = [];
         this.players_index = 0;
     }

--- a/test/glicko2.js
+++ b/test/glicko2.js
@@ -2,21 +2,23 @@ var glicko2 = require('../glicko2');
 
 describe('Glicko2', function(){
     describe('makePlayer()', function(){
-        var settings = {
-          tau : 0.5,
-          rpd : 604800,
-          rating : 1500,
-          rd : 350,
-          vol : 0.06
-        };
-        var glicko = new glicko2.Glicko2(settings);
-        it('should make a default player', function(){
+        it('should make a default player when passed no settings', function(){
+            var glicko = new glicko2.Glicko2();
             var player = glicko.makePlayer();
-            player.getRating().should.equal(settings.rating);
-            player.getRd().should.equal(settings.rd);
-            player.getVol().should.equal(settings.vol);
-          });
-      });
+            player.getRating().should.equal(1500);
+            player.getRd().should.equal(350);
+            player.getVol().should.equal(0.06);
+        });
+        it('should support setting invidual settings', function(){
+            var glicko = new glicko2.Glicko2({
+              rating: 1600
+            });
+            var player = glicko.makePlayer();
+            player.getRating().should.equal(1600);
+            player.getRd().should.equal(350);
+            player.getVol().should.equal(0.06);
+        });
+    });
     describe('getPlayers()', function(){
         it('should retrieve all players with ids', function(){
         var settings = {


### PR DESCRIPTION
Currently, the `Glicko2` class expects a complete `settings` _Object_. Thus, if one wanted to only change, say, the default rating, they **cannot** simply do this:

``` js
var glicko = new glicko2.Glicko2({
  rating: 1600
});
```

Instead, one must pass the entire `settings` _Object_, even if they want to change just one value:

``` js
var glicko = new glicko2.Glicko2({
  tau: 0.5,
  rating: 1600, // but I only wanted to worry about this :(
  rd: 350,
  vol: 0.06,
  volatility_algorithm: 'newprocedure'
});
```

This patch fixes this issue by checking for each individual setting in the `settings` _Object_ instead of just checking for the entire _Object_ itself. This way, one does not have to pass a complete `settings` _Object_ if they only want to change a few values.

An alternative way to do this would be to _extend_ the `default_settings` _Object_ (which this patch removes) with whatever is passed as `settings`. npm modules like [xtend](https://github.com/Raynos/xtend) and [lodash.assign](https://www.npmjs.org/package/lodash.assign) provide this functionality, but in order to maintain Bower support (which doesn't support `require()` calls), I would have had to setup a whole build system that would inline one of these modules before publish. Way too much work, especially for a tool I do not use.
