### PR TITLE
Prevent newer instances of `Glicko2` from affecting existing `Player`s

### DIFF
--- a/glicko2.js
+++ b/glicko2.js
@@ -127,14 +127,7 @@
     function Glicko2(settings){
         settings = settings || {};
 
-        // Default rating
-        Player.prototype.defaultRating = settings.rating || 1500;
-
-        // Defualt volatility calculation algorithm (step 5 of the global
-        // algorithm)
-        Player.prototype.volatility_algorithm = volatility_algorithms[settings.volatility_algorithm || 'newprocedure'];
-
-        // Internal glicko2 paramter. "Reasonable choices are between 0.3 and
+        // Internal glicko2 parameter. "Reasonable choices are between 0.3 and
         // 1.2, though the system should be tested to decide which value results
         // in greatest predictive accuracy."
         this._tau = settings.tau || 0.5;
@@ -148,6 +141,10 @@
 
         // Default volatility (expected fluctation on the player rating)
         this._default_vol = settings.vol || 0.06;
+
+        // Default volatility calculation algorithm (step 5 of the global
+        // algorithm)
+        this._volatility_algorithm = volatility_algorithms[settings.volatility_algorithm || 'newprocedure'];
 
         this.players = [];
         this.players_index = 0;
@@ -208,6 +205,23 @@
               }
           }
           var player = new Player(rating || this._default_rating, rd || this._default_rd, vol || this._default_vol, this._tau);
+          var playerProto = Object.getPrototypeOf(player);
+
+          // Set this specific Player's `defaultRating`. This _has_ to be done
+          // here in order to ensure that new `Glicko2` instances do not change
+          // the `defaultRating` of `Player` instances created under previous
+          // `Glicko2` instances.
+          playerProto.defaultRating = this._default_rating;
+
+          // Same reasoning and purpose as the above code regarding
+          // `defaultRating`
+          playerProto.volatility_algorithm = this._volatility_algorithm;
+
+          // Since this `Player`'s rating was calculated upon instantiation,
+          // before the `defaultRating` was defined above, we much re-calculate
+          // the rating manually.
+          player.setRating(rating || this._default_rating);
+
           player.id = id;
           player.adv_ranks = [];
           player.adv_rds = [];

--- a/test/glicko2.js
+++ b/test/glicko2.js
@@ -9,7 +9,7 @@ describe('Glicko2', function(){
             player.getRd().should.equal(350);
             player.getVol().should.equal(0.06);
         });
-        it('should support setting invidual settings', function(){
+        it('should support setting individual settings', function(){
             var glicko = new glicko2.Glicko2({
               rating: 1600
             });
@@ -17,6 +17,18 @@ describe('Glicko2', function(){
             player.getRating().should.equal(1600);
             player.getRd().should.equal(350);
             player.getVol().should.equal(0.06);
+        });
+        it('should not be affected by newer instances of Glicko2', function(){
+            var glicko = new glicko2.Glicko2({
+              rating: 1400
+            });
+            var player = glicko.makePlayer();
+
+            var newerGlicko = new glicko2.Glicko2({
+              rating: 1600
+            });
+
+            player.getRating().should.equal(1400);
         });
     });
     describe('getPlayers()', function(){


### PR DESCRIPTION
The test I've added should help illustrate this bug.

Before this patch, the `defaultRating` and `volatility_algorithm` of the `Player` class were defined upon the instantiation of a `Glicko2` instance. Thus, new `Glicko2` instances would affect the `defaultRating` and `volatility_algorithm` of already-instantiated `Player`s.

``` js
var glicko = new glicko2.Glicko2({
  rating: 1400
});
var player = glicko.makePlayer();

var newerGlicko = new glicko2.Glicko2({
  rating: 1600
});

player.getRating();
// => 1600
```

As seen in the above code, `player` was created under `glicko`, which sets the `defaultRating` to `1400`. However, the instantiation of `newerGlicko` re-defines `Player.prototype.defaultRating` to `1600`, causing `player`'s rating to change, despite having been created under `glicko`.

This fix moves the definition of `defaultRating` and `volatility_algorithm` to `makePlayer()`. Instead of changing the `prototype` of `Player`, the `prototype` of the specific `Player` created by `makePlayer()` is what's changed.

I've also fixed a couple of typos that I had made in #5.
