### PR TITLE
do not round deviation

### DIFF
--- a/glicko2.js
+++ b/glicko2.js
@@ -49,7 +49,7 @@
     };
 
     Player.prototype.getRd = function(){
-        return Math.round(100 * this.__rd * scalingFactor)/100;
+        return this.__rd * scalingFactor;
     };
 
     Player.prototype.setRd = function(rd){


### PR DESCRIPTION
To me, rounding the deviation to two decimal places seems arbitrary. I believe this kind of thing should be up to the user of this module. At least it allows one to round however they like.