### PR TITLE
Add license in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "glicko2",
+  "license": "MIT",
   "description": "glicko2 ranking system",
   "version": "1.2.0",
   "author": "Henri Bourcereau",


### PR DESCRIPTION
and prevent npm displaying "License: none"